### PR TITLE
Add possibility to change DB name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add it to `Cargo.toml`
 
 ```
 casbin = { version = "0.2.0" }
-diesel_adapter = { version = "0.2.0", features = ["postgres"] }
+diesel-adapter = { version = "0.2.0", features = ["postgres"] }
 async-std = "1.5.0"
 ```
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -146,8 +146,7 @@ mod tests {
             .set_auth("user", "pass")
             .set_port(1234)
             .set_hostname("example.com")
-            .set_database("db")
-        ;
+            .set_database("db");
 
         assert_eq!(
             "postgres://user:pass@example.com:1234/db",

--- a/src/models.rs
+++ b/src/models.rs
@@ -116,8 +116,12 @@ impl<'a> ConnOptions<'a> {
         self.table.to_owned()
     }
 
-    pub fn set_table(&mut self, table: &'a str) -> &mut Self {
-        self.table = table;
+    pub fn get_database(&self) -> String {
+        self.database.to_owned()
+    }
+
+    pub fn set_database(&mut self, database: &'a str) -> &mut Self {
+        self.database = database;
         self
     }
 
@@ -138,10 +142,15 @@ mod tests {
     fn test_url() {
         use super::*;
         let mut conn_options = ConnOptions::default();
-        conn_options.set_auth("test", "test");
+        conn_options
+            .set_auth("user", "pass")
+            .set_port(1234)
+            .set_hostname("example.com")
+            .set_database("db")
+        ;
 
         assert_eq!(
-            "postgres://test:test@127.0.0.1:5432/casbin",
+            "postgres://user:pass@example.com:1234/db",
             conn_options.get_url()
         )
     }


### PR DESCRIPTION
It doesn't make sense to change the table name, since we have "casbin_rules" name everywhere we define Diesel.

In the other hand, it makes sense to change DB name, and it was not possible. So I've added this.