### PR TITLE
add missing implementation for casbin@0.3.0 and make unique key constraint works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,20 @@ homepage="https://github.com/casbin-rs/diesel-adapter"
 readme="README.md"
 
 [dependencies]
-casbin = { version = "0.2.0" }
-diesel = { version = "1.4.3", features = ["r2d2", "postgres", "mysql"] }
+casbin = { version = "0.3.0" }
+diesel = { version = "1.4.3", features = ["r2d2"] }
 async-trait = "0.1.24"
 
 [features]
-default = ["postgres"]
+default = ["postgres", "runtime-async-std"]
 
 postgres = ["diesel/postgres"]
 mysql = ["diesel/mysql"]
 
+runtime-tokio = ["casbin/runtime-tokio"]
+runtime-async-std = ["casbin/runtime-async-std"]
+
 [dev-dependencies]
-async-std = "1.5.0"
+async-std = { version = "1.5.0", features = [ "attributes" ] }
+tokio = { version = "0.2.11", features = [ "full" ] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-adapter"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Cheng JIANG <jiang.cheng@vip.163.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ An adapter designed to work with [casbin-rs](https://github.com/casbin/casbin-rs
 Add it to `Cargo.toml`
 
 ```
-casbin = { version = "0.2.0" }
-diesel-adapter = { version = "0.2.0", features = ["postgres"] }
+casbin = { version = "0.3.0" }
+diesel-adapter = { version = "0.3.0", features = ["postgres"] }
 async-std = "1.5.0"
 ```
 
@@ -21,12 +21,12 @@ async-std = "1.5.0"
 ## Example
 
 ```rust
-use casbin::{Enforcer, FileAdapter, Model};
+use casbin::{Enforcer, FileAdapter, DefaultModel};
 use diesel_adapter::{DieselAdapter, ConnOptions};
-use async_std::task;
 
-task::block_on(async {
-    let mut m = Model::from_file("examples/rbac_model.conf").await?;
+#[async_std::main]
+async fn main() {
+    let mut m = Box::new(DefaultModel::from_file("examples/rbac_model.conf").await?);
 
     let mut conn_opts = ConnOptions::default();
     conn_opts
@@ -37,7 +37,7 @@ task::block_on(async {
 
     let a = Box::new(DieselAdapter::new(conn_opts).await?);
     let mut e = Enforcer::new(m, a).await?;
-});
+};
 ```
 
 ## Features

--- a/scripts/login-db.sh
+++ b/scripts/login-db.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ ! $# > 0 ]]; then
+    echo "help: ./login-db.sh --mysql|--postgres" && exit 1;
+elif [ "$1" == "--postgres" ]; then
+    psql postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin;
+elif [ "$1" == "--mysql" ]; then
+    mysql -h 127.0.0.1 -u casbin_rs -pcasbin_rs casbin;
+else
+    echo "invalid argument: $1" && exit 1;
+fi

--- a/scripts/setup-db.sh
+++ b/scripts/setup-db.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+DIS=$(lsb_release -is)
+
+command -v docker > /dev/null 2>&1 || {
+    echo "Please install docker before running this script." && exit 1;
+}
+
+if [ $DIS == "Ubuntu" ]; then
+    sudo apt install -y \
+        libpq-dev \
+        libmysqlclient-dev \
+        postgresql-client \
+        mysql-client-core;
+
+elif [ $DIS == "Deepin" ]; then
+    sudo apt install -y \
+        libpq-dev \
+        libmysql++-dev \
+        mysql-client \
+        postgresql-client;
+else
+    echo "Unsupported system: $DIS" && exit 1;
+fi
+
+docker run -itd \
+    --restart always \
+    -e POSTGRES_USER=casbin_rs \
+    -e POSTGRES_PASSWORD=casbin_rs \
+    -e POSTGRES_DB=casbin \
+    -p 5432:5432 \
+    -v /srv/docker/postgresql:/var/lib/postgresql \
+    postgres:11;
+
+docker run -itd \
+    --restart always \
+    -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+    -e MYSQL_USER=casbin_rs \
+    -e MYSQL_PASSWORD=casbin_rs \
+    -e MYSQL_DATABASE=casbin \
+    -p 3306:3306 \
+    -v /srv/docker/mysql:/var/lib/mysql \
+    mysql:8 \
+    --default-authentication-plugin=mysql_native_password;

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -3,7 +3,8 @@ use casbin::{Adapter, Model, Result};
 use diesel::{
     self,
     r2d2::{ConnectionManager, Pool},
-    RunQueryDsl,
+    result::Error as DieselError,
+    Connection, RunQueryDsl,
 };
 
 use crate::{error::*, models::*, schema};
@@ -30,64 +31,81 @@ impl<'a> DieselAdapter {
             .get()
             .map_err(|err| Box::new(Error::PoolError(err)) as Box<dyn StdError>);
 
-        adapter::new(conn).map(|_x| Self { pool })
+        adapter::new(conn).map(|_| Self { pool })
     }
 
-    pub(crate) fn save_policy_line(&self, ptype: &'a str, rule: Vec<&'a str>) -> NewCasbinRule<'a> {
-        let mut new_rule = NewCasbinRule {
-            ptype: Some(ptype),
-            v0: None,
-            v1: None,
-            v2: None,
-            v3: None,
-            v4: None,
-            v5: None,
-        };
-
-        if !rule.is_empty() {
-            new_rule.v0 = Some(rule[0]);
+    pub(crate) fn save_policy_line(
+        &self,
+        ptype: &'a str,
+        rule: Vec<&'a str>,
+    ) -> Option<NewCasbinRule<'a>> {
+        if ptype.trim().is_empty() || rule.is_empty() {
+            return None;
         }
 
+        let mut new_rule = NewCasbinRule {
+            ptype,
+            v0: "",
+            v1: "",
+            v2: "",
+            v3: "",
+            v4: "",
+            v5: "",
+        };
+
+        new_rule.v0 = rule[0];
+
         if rule.len() > 1 {
-            new_rule.v1 = Some(rule[1]);
+            new_rule.v1 = rule[1];
         }
 
         if rule.len() > 2 {
-            new_rule.v2 = Some(rule[2]);
+            new_rule.v2 = rule[2];
         }
 
         if rule.len() > 3 {
-            new_rule.v3 = Some(rule[3]);
+            new_rule.v3 = rule[3];
         }
 
         if rule.len() > 4 {
-            new_rule.v4 = Some(rule[4]);
+            new_rule.v4 = rule[4];
         }
 
         if rule.len() > 5 {
-            new_rule.v5 = Some(rule[5]);
+            new_rule.v5 = rule[5];
         }
 
-        new_rule
+        Some(new_rule)
     }
 
     pub(crate) fn load_policy_line(&self, casbin_rule: &CasbinRule) -> Option<Vec<String>> {
-        if let Some(ref sec) = casbin_rule.ptype {
-            if sec.chars().next().is_some() {
-                return Some(
-                    vec![
-                        &casbin_rule.v0,
-                        &casbin_rule.v1,
-                        &casbin_rule.v2,
-                        &casbin_rule.v3,
-                        &casbin_rule.v4,
-                        &casbin_rule.v5,
-                    ]
-                    .iter()
-                    .filter_map(|&x| x.as_ref().map(|x| x.to_owned()))
-                    .collect::<Vec<String>>(),
-                );
+        if casbin_rule.ptype.chars().next().is_some() {
+            return self.normalize_policy(casbin_rule);
+        }
+
+        None
+    }
+
+    fn normalize_policy(&self, casbin_rule: &CasbinRule) -> Option<Vec<String>> {
+        let mut result = vec![
+            &casbin_rule.v0,
+            &casbin_rule.v1,
+            &casbin_rule.v2,
+            &casbin_rule.v3,
+            &casbin_rule.v4,
+            &casbin_rule.v5,
+        ];
+
+        while let Some(last) = result.last() {
+            if last.is_empty() {
+                result.pop();
+            } else {
+                break;
             }
+        }
+
+        if !result.is_empty() {
+            return Some(result.iter().map(|&x| x.to_owned()).collect());
         }
 
         None
@@ -96,7 +114,7 @@ impl<'a> DieselAdapter {
 
 #[async_trait]
 impl Adapter for DieselAdapter {
-    async fn load_policy(&self, m: &mut Model) -> Result<()> {
+    async fn load_policy(&self, m: &mut dyn Model) -> Result<()> {
         use schema::casbin_rules::dsl::casbin_rules;
 
         let conn = self
@@ -111,13 +129,11 @@ impl Adapter for DieselAdapter {
         for casbin_rule in &rules {
             let rule = self.load_policy_line(casbin_rule);
 
-            if let Some(ref ptype) = casbin_rule.ptype {
-                if let Some(ref sec) = ptype.chars().next().map(|x| x.to_string()) {
-                    if let Some(t1) = m.get_mut_model().get_mut(sec) {
-                        if let Some(t2) = t1.get_mut(ptype) {
-                            if let Some(rule) = rule {
-                                t2.get_mut_policy().insert(rule);
-                            }
+            if let Some(ref sec) = casbin_rule.ptype.chars().next().map(|x| x.to_string()) {
+                if let Some(t1) = m.get_mut_model().get_mut(sec) {
+                    if let Some(t2) = t1.get_mut(&casbin_rule.ptype) {
+                        if let Some(rule) = rule {
+                            t2.get_mut_policy().insert(rule);
                         }
                     }
                 }
@@ -127,7 +143,7 @@ impl Adapter for DieselAdapter {
         Ok(())
     }
 
-    async fn save_policy(&self, m: &mut Model) -> Result<()> {
+    async fn save_policy(&mut self, m: &mut dyn Model) -> Result<()> {
         use schema::casbin_rules::dsl::casbin_rules;
 
         let conn = self
@@ -139,45 +155,42 @@ impl Adapter for DieselAdapter {
             .execute(&conn)
             .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)?;
 
-        if let Some(ast_map) = m.get_mut_model().get("p") {
-            for (ptype, ast) in ast_map {
-                for rule in ast.get_policy() {
-                    let new_rule = self.save_policy_line(
-                        ptype,
-                        rule.iter().map(|x| x.as_str()).collect::<Vec<&str>>(),
-                    );
+        let mut rules = vec![];
 
-                    if let Err(err) = diesel::insert_into(casbin_rules)
-                        .values(&new_rule)
-                        .execute(&conn)
-                        .map_err(|err| Box::new(Error::DieselError(err)))
-                    {
-                        return Err(err);
-                    }
-                }
+        if let Some(ast_map) = m.get_model().get("p") {
+            for (ptype, ast) in ast_map {
+                let new_rules = ast.get_policy().into_iter().filter_map(|x: &Vec<String>| {
+                    self.save_policy_line(
+                        ptype,
+                        x.iter().map(|y| y.as_str()).collect::<Vec<&str>>(),
+                    )
+                });
+
+                rules.extend(new_rules);
             }
         }
 
-        if let Some(ast_map) = m.get_mut_model().get("g") {
+        if let Some(ast_map) = m.get_model().get("g") {
             for (ptype, ast) in ast_map {
-                for rule in ast.get_policy() {
-                    let new_rule = self.save_policy_line(
+                let new_rules = ast.get_policy().into_iter().filter_map(|x: &Vec<String>| {
+                    self.save_policy_line(
                         ptype,
-                        rule.iter().map(|x| x.as_str()).collect::<Vec<&str>>(),
-                    );
+                        x.iter().map(|y| y.as_str()).collect::<Vec<&str>>(),
+                    )
+                });
 
-                    if let Err(err) = diesel::insert_into(casbin_rules)
-                        .values(&new_rule)
-                        .execute(&conn)
-                        .map_err(|err| Box::new(Error::DieselError(err)))
-                    {
-                        return Err(err);
-                    }
-                }
+                rules.extend(new_rules);
             }
         }
 
-        Ok(())
+        conn.transaction::<_, DieselError, _>(|| {
+            diesel::insert_into(casbin_rules)
+                .values(&rules)
+                .execute(&conn)
+                .map_err(|_| DieselError::RollbackTransaction)
+        })
+        .map(|_| ())
+        .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
     }
 
     async fn add_policy(&mut self, _sec: &str, ptype: &str, rule: Vec<&str>) -> Result<bool> {
@@ -188,16 +201,46 @@ impl Adapter for DieselAdapter {
             .get()
             .map_err(|err| Box::new(Error::PoolError(err)) as Box<dyn StdError>)?;
 
-        let new_rule = self.save_policy_line(ptype, rule);
+        if let Some(new_rule) = self.save_policy_line(ptype, rule) {
+            return diesel::insert_into(casbin_rules)
+                .values(&new_rule)
+                .execute(&conn)
+                .map(|n| if n == 1 { true } else { false })
+                .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>);
+        }
 
-        diesel::insert_into(casbin_rules)
-            .values(&new_rule)
-            .execute(&conn)
-            .and_then(|n| if n == 1 { Ok(true) } else { Ok(false) })
-            .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
+        Ok(false)
     }
 
-    async fn remove_policy(&self, _sec: &str, pt: &str, rule: Vec<&str>) -> Result<bool> {
+    async fn add_policies(
+        &mut self,
+        _sec: &str,
+        ptype: &str,
+        rules: Vec<Vec<&str>>,
+    ) -> Result<bool> {
+        use schema::casbin_rules::dsl::casbin_rules;
+
+        let conn = self
+            .pool
+            .get()
+            .map_err(|err| Box::new(Error::PoolError(err)) as Box<dyn StdError>)?;
+
+        let new_rules = rules
+            .into_iter()
+            .filter_map(|x: Vec<&str>| self.save_policy_line(ptype, x))
+            .collect::<Vec<NewCasbinRule>>();
+
+        conn.transaction::<_, DieselError, _>(|| {
+            diesel::insert_into(casbin_rules)
+                .values(&new_rules)
+                .execute(&conn)
+                .map_err(|_| DieselError::RollbackTransaction)
+        })
+        .map(|_| true)
+        .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
+    }
+
+    async fn remove_policy(&mut self, _sec: &str, pt: &str, rule: Vec<&str>) -> Result<bool> {
         let conn = self
             .pool
             .get()
@@ -206,14 +249,28 @@ impl Adapter for DieselAdapter {
         adapter::remove_policy(conn, pt, rule)
     }
 
+    async fn remove_policies(
+        &mut self,
+        _sec: &str,
+        pt: &str,
+        rules: Vec<Vec<&str>>,
+    ) -> Result<bool> {
+        let conn = self
+            .pool
+            .get()
+            .map_err(|err| Box::new(Error::PoolError(err)) as Box<dyn StdError>)?;
+
+        adapter::remove_policies(conn, pt, rules)
+    }
+
     async fn remove_filtered_policy(
-        &self,
+        &mut self,
         _sec: &str,
         pt: &str,
         field_index: usize,
         field_values: Vec<&str>,
     ) -> Result<bool> {
-        if field_index <= 5 && !field_values.is_empty() && field_values.len() <= 6 - field_index {
+        if field_index <= 5 && !field_values.is_empty() && field_values.len() >= 6 - field_index {
             let conn = self
                 .pool
                 .get()
@@ -230,136 +287,147 @@ impl Adapter for DieselAdapter {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_adapter() {
-        // # Ubuntu
-        // sudo apt install libpq-dev libmysqlclient-dev
-        //
-        // # Deepin
-        // sudo apt install libpq-dev libmysql++-dev
-        //
-        // docker run -itd --restart always -e POSTGRES_USER=casbin_rs -e POSTGRES_PASSWORD=casbin_rs -e POSTGRES_DB=casbin -p 5432:5432 -v /srv/docker/postgresql:/var/lib/postgresql postgres:11;
-        // docker run -itd --restart always -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -e MYSQL_USER=casbin_rs -e MYSQL_PASSWORD=casbin_rs -e MYSQL_DATABASE=casbin -p 3306:3306 -v /srv/docker/mysql:/var/lib/mysql mysql:8 --default-authentication-plugin=mysql_native_password;
-        //
-        //  # Ubuntu
-        //  sudo apt install postgresql-client-11 mysql-client-core-8.0
-        //
-        //  # Deepin
-        //  sudo apt install mysql-client postgresql-client-9.6
-        //
-        //  psql postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin;
-        //  mysql -h 127.0.0.1 -u casbin_rs -p
-        //
-        // To run the test against postgresql:
-        // cargo test
-        //
-        // To run the test against mysql:
-        // cargo test --no-default-features --features mysql
-        //
-        use async_std::task;
-        use casbin::{Enforcer, FileAdapter, Model};
+    #[cfg_attr(feature = "runtime-async-std", async_std::test)]
+    #[cfg_attr(feature = "runtime-tokio", tokio::test)]
+    async fn test_adapter() {
+        use casbin::{DefaultModel, Enforcer, FileAdapter};
 
         let mut conn_opts = ConnOptions::default();
         conn_opts.set_auth("casbin_rs", "casbin_rs");
         let file_adapter = Box::new(FileAdapter::new("examples/rbac_policy.csv"));
 
-        task::block_on(async move {
-            let m = Model::from_file("examples/rbac_model.conf").await.unwrap();
+        let m = DefaultModel::from_file("examples/rbac_model.conf")
+            .await
+            .unwrap();
 
-            let mut e = Enforcer::new(m, file_adapter).await.unwrap();
-            let mut adapter = DieselAdapter::new(conn_opts).unwrap();
+        let mut e = Enforcer::new(Box::new(m), file_adapter).await.unwrap();
+        let mut adapter = DieselAdapter::new(conn_opts).unwrap();
 
-            assert!(adapter.save_policy(&mut e.get_mut_model()).await.is_ok());
+        assert!(adapter.save_policy(e.get_mut_model()).await.is_ok());
 
-            assert!(adapter
-                .remove_policy("", "p", vec!["alice", "data1", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["bob", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["data2_admin", "data2", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["data2_admin", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "g", vec!["alice", "data2_admin"])
-                .await
-                .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["alice", "data1", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["bob", "data2", "write"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["data2_admin", "data2", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["data2_admin", "data2", "write"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "g", vec!["alice", "data2_admin"])
+            .await
+            .is_ok());
 
-            assert!(adapter
-                .add_policy("", "p", vec!["alice", "data1", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .add_policy("", "p", vec!["bob", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .add_policy("", "p", vec!["data2_admin", "data2", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .add_policy("", "p", vec!["data2_admin", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .add_policy("", "g", vec!["alice", "data2_admin"])
-                .await
-                .is_ok());
+        assert!(adapter
+            .add_policy("", "p", vec!["alice", "data1", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .add_policy("", "p", vec!["bob", "data2", "write"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .add_policy("", "p", vec!["data2_admin", "data2", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .add_policy("", "p", vec!["data2_admin", "data2", "write"])
+            .await
+            .is_ok());
 
-            assert!(adapter
-                .remove_policy("", "p", vec!["alice", "data1", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["bob", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["data2_admin", "data2", "read"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "p", vec!["data2_admin", "data2", "write"])
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_policy("", "g", vec!["alice", "data2_admin"])
-                .await
-                .is_ok());
+        assert!(adapter
+            .remove_policies(
+                "",
+                "p",
+                vec![
+                    vec!["alice", "data1", "read"],
+                    vec!["bob", "data2", "write"],
+                    vec!["data2_admin", "data2", "read"],
+                    vec!["data2_admin", "data2", "write"],
+                ]
+            )
+            .await
+            .is_ok());
 
-            assert!(!adapter
-                .remove_policy("", "g", vec!["alice", "data2_admin", "not_exists"])
-                .await
-                .is_ok());
+        assert!(adapter
+            .add_policies(
+                "",
+                "p",
+                vec![
+                    vec!["alice", "data1", "read"],
+                    vec!["bob", "data2", "write"],
+                    vec!["data2_admin", "data2", "read"],
+                    vec!["data2_admin", "data2", "write"],
+                ]
+            )
+            .await
+            .is_ok());
 
-            assert!(adapter
-                .add_policy("", "g", vec!["alice", "data2_admin"])
-                .await
-                .is_ok());
-            assert!(!adapter
-                .remove_filtered_policy("", "g", 0, vec!["alice", "data2_admin", "not_exists"],)
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_filtered_policy("", "g", 0, vec!["alice", "data2_admin"])
-                .await
-                .is_ok());
+        assert!(adapter
+            .add_policy("", "g", vec!["alice", "data2_admin"])
+            .await
+            .is_ok());
 
-            assert!(adapter
-                .add_policy("", "g", vec!["alice", "data2_admin", "domain1", "domain2"],)
-                .await
-                .is_ok());
-            assert!(adapter
-                .remove_filtered_policy("", "g", 1, vec!["data2_admin", "domain1", "domain2"],)
-                .await
-                .is_ok());
-        });
+        assert!(adapter
+            .remove_policy("", "p", vec!["alice", "data1", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["bob", "data2", "write"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["data2_admin", "data2", "read"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "p", vec!["data2_admin", "data2", "write"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_policy("", "g", vec!["alice", "data2_admin"])
+            .await
+            .is_ok());
+
+        assert!(!adapter
+            .remove_policy("", "g", vec!["alice", "data2_admin", "not_exists"])
+            .await
+            .is_ok());
+
+        assert!(adapter
+            .add_policy("", "g", vec!["alice", "data2_admin"])
+            .await
+            .is_ok());
+        assert!(adapter
+            .add_policy("", "g", vec!["alice", "data2_admin"])
+            .await
+            .is_err());
+
+        assert!(!adapter
+            .remove_filtered_policy("", "g", 0, vec!["alice", "data2_admin", "not_exists"],)
+            .await
+            .unwrap());
+
+        assert!(adapter
+            .remove_filtered_policy("", "g", 0, vec!["alice", "data2_admin"])
+            .await
+            .is_ok());
+
+        assert!(adapter
+            .add_policy("", "g", vec!["alice", "data2_admin", "domain1", "domain2"],)
+            .await
+            .is_ok());
+        assert!(adapter
+            .remove_filtered_policy("", "g", 1, vec!["data2_admin", "domain1", "domain2"],)
+            .await
+            .is_ok());
     }
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -205,7 +205,7 @@ impl Adapter for DieselAdapter {
             return diesel::insert_into(casbin_rules)
                 .values(&new_rule)
                 .execute(&conn)
-                .map(|n| if n == 1 { true } else { false })
+                .map(|n| n == 1)
                 .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>);
         }
 

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -3,31 +3,15 @@ use crate::Error;
 use casbin::Result;
 use diesel::{
     self,
-    dsl::sql,
     r2d2::{ConnectionManager, PooledConnection},
     result::Error as DieselError,
-    sql_query, BoolExpressionMethods, ExpressionMethods, MysqlConnection, QueryDsl, RunQueryDsl,
+    sql_query, BoolExpressionMethods, Connection as DieselConnection, ExpressionMethods,
+    MysqlConnection, QueryDsl, RunQueryDsl,
 };
 
 use std::error::Error as StdError;
 
 use crate::adapter::TABLE_NAME;
-
-macro_rules! eq_null {
-    ($v:expr,$field:expr) => {{
-        || {
-            use crate::diesel::BoolExpressionMethods;
-
-            sql("")
-                .bind::<diesel::sql_types::Bool, _>($v.is_none())
-                .and($field.is_null())
-                .or(sql("")
-                    .bind::<diesel::sql_types::Bool, _>(!$v.is_none())
-                    .and($field.eq($v)))
-        }
-    }
-    ()};
-}
 
 pub type Connection = MysqlConnection;
 type Pool = PooledConnection<ConnectionManager<Connection>>;
@@ -38,13 +22,13 @@ pub fn new(conn: Result<Pool>) -> Result<usize> {
             r#"
                 CREATE TABLE IF NOT EXISTS {} (
                     id INT NOT NULL AUTO_INCREMENT,
-                    ptype VARCHAR(12),
-                    v0 VARCHAR(128),
-                    v1 VARCHAR(128),
-                    v2 VARCHAR(128),
-                    v3 VARCHAR(128),
-                    v4 VARCHAR(128),
-                    v5 VARCHAR(128),
+                    ptype VARCHAR(12) NOT NULL,
+                    v0 VARCHAR(128) NOT NULL,
+                    v1 VARCHAR(128) NOT NULL,
+                    v2 VARCHAR(128) NOT NULL,
+                    v3 VARCHAR(128) NOT NULL,
+                    v4 VARCHAR(128) NOT NULL,
+                    v5 VARCHAR(128) NOT NULL,
                     PRIMARY KEY(id),
                     CONSTRAINT unique_key UNIQUE(ptype, v0, v1, v2, v3, v4, v5)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -59,28 +43,60 @@ pub fn new(conn: Result<Pool>) -> Result<usize> {
 pub fn remove_policy(conn: Pool, pt: &str, rule: Vec<&str>) -> Result<bool> {
     use schema::casbin_rules::dsl::*;
 
-    diesel::delete(
-        casbin_rules.filter(
-            ptype.eq(pt).and(
-                eq_null!(rule.get(0), v0).and(
-                    eq_null!(rule.get(1), v1)
-                        .and(eq_null!(rule.get(2), v2))
-                        .and(
-                            eq_null!(rule.get(3), v3)
-                                .and(eq_null!(rule.get(4), v4))
-                                .and(eq_null!(rule.get(5), v5)),
-                        ),
-                ),
-            ),
-        ),
-    )
-    .execute(&conn)
-    .and_then(|n| {
-        if n == 1 {
-            Ok(true)
-        } else {
-            Err(DieselError::NotFound)
+    let rule = normalize_casbin_rule(rule, 0);
+
+    let filter = ptype
+        .eq(pt)
+        .and(v0.eq(rule[0]))
+        .and(v1.eq(rule[1]))
+        .and(v2.eq(rule[2]))
+        .and(v3.eq(rule[3]))
+        .and(v4.eq(rule[4]))
+        .and(v5.eq(rule[5]));
+
+    diesel::delete(casbin_rules.filter(filter))
+        .execute(&conn)
+        .and_then(|n| {
+            if n == 1 {
+                Ok(true)
+            } else {
+                Err(DieselError::NotFound)
+            }
+        })
+        .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
+}
+
+pub fn remove_policies(conn: Pool, pt: &str, rules: Vec<Vec<&str>>) -> Result<bool> {
+    use schema::casbin_rules::dsl::*;
+
+    conn.transaction::<_, DieselError, _>(|| {
+        for rule in rules {
+            let rule = normalize_casbin_rule(rule, 0);
+
+            let filter = ptype
+                .eq(pt)
+                .and(v0.eq(rule[0]))
+                .and(v1.eq(rule[1]))
+                .and(v2.eq(rule[2]))
+                .and(v3.eq(rule[3]))
+                .and(v4.eq(rule[4]))
+                .and(v5.eq(rule[5]));
+
+            if let Err(_) = diesel::delete(casbin_rules.filter(filter))
+                .execute(&conn)
+                .and_then(|n| {
+                    if n == 1 {
+                        Ok(true)
+                    } else {
+                        Err(DieselError::NotFound)
+                    }
+                })
+            {
+                return Err(DieselError::RollbackTransaction);
+            }
         }
+
+        Ok(true)
     })
     .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
 }
@@ -93,80 +109,86 @@ pub fn remove_filtered_policy(
 ) -> Result<bool> {
     use schema::casbin_rules::dsl::*;
 
-    (if field_index == 0 {
-        diesel::delete(
-            casbin_rules.filter(
-                ptype.eq(pt).and(
-                    eq_null!(field_values.get(0), v0).and(
-                        eq_null!(field_values.get(1), v1)
-                            .and(eq_null!(field_values.get(2), v2))
-                            .and(
-                                eq_null!(field_values.get(3), v3)
-                                    .and(eq_null!(field_values.get(4), v4))
-                                    .and(eq_null!(field_values.get(5), v5)),
-                            ),
-                    ),
-                ),
-            ),
-        )
-        .execute(&conn)
-    } else if field_index == 1 {
-        diesel::delete(
-            casbin_rules.filter(
-                ptype.eq(pt).and(
-                    eq_null!(field_values.get(0), v1)
-                        .and(eq_null!(field_values.get(1), v2))
-                        .and(
-                            eq_null!(field_values.get(2), v3)
-                                .and(eq_null!(field_values.get(3), v4))
-                                .and(eq_null!(field_values.get(4), v5)),
-                        ),
-                ),
-            ),
-        )
-        .execute(&conn)
-    } else if field_index == 2 {
-        diesel::delete(
-            casbin_rules.filter(
-                ptype.eq(pt).and(
-                    eq_null!(field_values.get(0), v2)
-                        .and(eq_null!(field_values.get(1), v3))
-                        .and(eq_null!(field_values.get(2), v4)),
-                ),
-            ),
-        )
-        .execute(&conn)
-    } else if field_index == 3 {
-        diesel::delete(
-            casbin_rules.filter(
-                ptype.eq(pt).and(
-                    eq_null!(field_values.get(0), v3)
-                        .and(eq_null!(field_values.get(1), v4))
-                        .and(eq_null!(field_values.get(2), v5)),
-                ),
-            ),
-        )
-        .execute(&conn)
+    let field_values = normalize_casbin_rule(field_values, field_index);
+
+    let boxed_query = if field_index == 5 {
+        diesel::delete(casbin_rules.filter(ptype.eq(pt).and(eq_empty!(field_values[0], v5))))
+            .into_boxed()
     } else if field_index == 4 {
         diesel::delete(
             casbin_rules.filter(
                 ptype
                     .eq(pt)
-                    .and(eq_null!(field_values.get(0), v4))
-                    .and(eq_null!(field_values.get(1), v5)),
+                    .and(eq_empty!(field_values[0], v4))
+                    .and(eq_empty!(field_values[1], v5)),
             ),
         )
-        .execute(&conn)
+        .into_boxed()
+    } else if field_index == 3 {
+        diesel::delete(
+            casbin_rules.filter(
+                ptype
+                    .eq(pt)
+                    .and(eq_empty!(field_values[0], v3))
+                    .and(eq_empty!(field_values[1], v4))
+                    .and(eq_empty!(field_values[2], v5)),
+            ),
+        )
+        .into_boxed()
+    } else if field_index == 2 {
+        diesel::delete(
+            casbin_rules.filter(
+                ptype
+                    .eq(pt)
+                    .and(eq_empty!(field_values[0], v2))
+                    .and(eq_empty!(field_values[1], v3))
+                    .and(eq_empty!(field_values[2], v4))
+                    .and(eq_empty!(field_values[3], v5)),
+            ),
+        )
+        .into_boxed()
+    } else if field_index == 1 {
+        diesel::delete(
+            casbin_rules.filter(
+                ptype
+                    .eq(pt)
+                    .and(eq_empty!(field_values[0], v1))
+                    .and(eq_empty!(field_values[1], v2))
+                    .and(eq_empty!(field_values[2], v3))
+                    .and(eq_empty!(field_values[3], v4))
+                    .and(eq_empty!(field_values[4], v5)),
+            ),
+        )
+        .into_boxed()
     } else {
-        diesel::delete(casbin_rules.filter(ptype.eq(pt).and(eq_null!(field_values.get(0), v5))))
-            .execute(&conn)
-    })
-    .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
-    .and_then(|n| {
-        if n == 1 {
-            Ok(true)
-        } else {
-            Err(Box::new(Error::DieselError(DieselError::NotFound)) as Box<dyn StdError>)
-        }
-    })
+        diesel::delete(
+            casbin_rules.filter(
+                ptype
+                    .eq(pt)
+                    .and(eq_empty!(field_values[0], v0))
+                    .and(eq_empty!(field_values[1], v1))
+                    .and(eq_empty!(field_values[2], v2))
+                    .and(eq_empty!(field_values[3], v3))
+                    .and(eq_empty!(field_values[4], v4))
+                    .and(eq_empty!(field_values[5], v5)),
+            ),
+        )
+        .into_boxed()
+    };
+
+    boxed_query
+        .execute(&conn)
+        .map_err(|err| Box::new(Error::DieselError(err)) as Box<dyn StdError>)
+        .and_then(|n| {
+            if n == 1 {
+                Ok(true)
+            } else {
+                Err(Box::new(Error::DieselError(DieselError::NotFound)) as Box<dyn StdError>)
+            }
+        })
+}
+
+fn normalize_casbin_rule(mut rule: Vec<&str>, field_index: usize) -> Vec<&str> {
+    rule.resize(6 - field_index, "");
+    rule
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ extern crate diesel;
 
 mod adapter;
 mod error;
+
+#[macro_use]
+mod macros;
 mod models;
 mod schema;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,14 @@
+macro_rules! eq_empty {
+    ($v:expr,$field:expr) => {{
+        || {
+            use diesel::BoolExpressionMethods;
+
+            diesel::dsl::sql("")
+                .bind::<diesel::sql_types::Bool, _>($v.is_empty())
+                .or(diesel::dsl::sql("")
+                    .bind::<diesel::sql_types::Bool, _>(!$v.is_empty())
+                    .and($field.eq($v)))
+        }
+    }
+    ()};
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,25 +3,25 @@ use super::schema::casbin_rules;
 #[derive(Queryable, Identifiable)]
 pub(crate) struct CasbinRule {
     pub id: i32,
-    pub ptype: Option<String>,
-    pub v0: Option<String>,
-    pub v1: Option<String>,
-    pub v2: Option<String>,
-    pub v3: Option<String>,
-    pub v4: Option<String>,
-    pub v5: Option<String>,
+    pub ptype: String,
+    pub v0: String,
+    pub v1: String,
+    pub v2: String,
+    pub v3: String,
+    pub v4: String,
+    pub v5: String,
 }
 
 #[derive(Insertable)]
 #[table_name = "casbin_rules"]
 pub(crate) struct NewCasbinRule<'a> {
-    pub ptype: Option<&'a str>,
-    pub v0: Option<&'a str>,
-    pub v1: Option<&'a str>,
-    pub v2: Option<&'a str>,
-    pub v3: Option<&'a str>,
-    pub v4: Option<&'a str>,
-    pub v5: Option<&'a str>,
+    pub ptype: &'a str,
+    pub v0: &'a str,
+    pub v1: &'a str,
+    pub v2: &'a str,
+    pub v3: &'a str,
+    pub v4: &'a str,
+    pub v5: &'a str,
 }
 
 #[derive(Clone, Debug)]
@@ -46,8 +46,6 @@ impl<'a> Default for ConnOptions<'a> {
                 pool_size: 8,
             }
         } else {
-            // We have to have an else here and
-            // the else should be the default "feature"
             ConnOptions {
                 hostname: "127.0.0.1",
                 port: 5432,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,12 +1,12 @@
 table! {
     casbin_rules (id) {
         id -> Integer,
-        ptype -> Nullable<Varchar>,
-        v0 -> Nullable<Varchar>,
-        v1 -> Nullable<Varchar>,
-        v2 -> Nullable<Varchar>,
-        v3 -> Nullable<Varchar>,
-        v4 -> Nullable<Varchar>,
-        v5 -> Nullable<Varchar>,
+        ptype -> Varchar,
+        v0 -> Varchar,
+        v1 -> Varchar,
+        v2 -> Varchar,
+        v3 -> Varchar,
+        v4 -> Varchar,
+        v5 -> Varchar,
     }
 }


### PR DESCRIPTION
Hello, this PR make unique key works for policy rules, before it cannot work because we do have nullable fields.

Now we are adding empty string to solve this issue.

Besides, it adds implementation of `add_policies` and `remove_policies` using diesel transaction.