### PR TITLE
Fix lifetime parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           override: true
 
       - name: Install PostgreSQL & MySQL Dependencies
-        run: sudo apt-get install libpq-dev postgresql-client mysql-client libmysqlclient-dev
+        run: sudo apt-get update && sudo apt-get install libpq-dev postgresql-client mysql-client libmysqlclient-dev
 
       - name: Cargo Build
         uses: actions-rs/cargo@v1

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -184,7 +184,7 @@ impl Adapter for DieselAdapter {
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, m: &mut dyn Model, f: Filter<'a>) -> Result<()> {
         let conn = self
             .pool
             .get()


### PR DESCRIPTION
When trying to compile with rust-1.45.0(also 1.44.0) I was getting the following error:
```rust
error[E0726]: implicit elided lifetime not allowed here
   --> src/adapter.rs:187:68
    |
187 |     async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
    |                                                                    ^^^^^^- help: indicate the anonymous lifetime: `<'_>`
```

Adding the lifetime parameter explicitly resolves the problem.
