### PR TITLE
docs: enable macros and rt-multi-thread features of tokio

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add it to `Cargo.toml`
 
 ```
 diesel-adapter = { version = "0.9.0", features = ["postgres"] }
-tokio = "1.1.1"
+tokio = { version = "1.1.1", features = ["macros", "rt-multi-thread"] }
 ```
 **Warning**: `tokio v1.0` or later is supported from `diesel-adapter v0.9.0`, we recommend that you upgrade the relevant components to ensure that they work properly. The last version that supports `tokio v0.2` is `diesel-adapter v0.8.3` , you can choose according to your needs.
 


### PR DESCRIPTION
I failed to build demo in README, getting errors like:
```bash
error[E0433]: failed to resolve: could not find `main` in `tokio`
 --> src/main.rs:5:10
  |
5 | #[tokio::main]
  |          ^^^^ could not find `main` in `tokio`
```
```bash
error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
 --> src/main.rs:5:1
  |
5 | #[tokio::main]
  | ^^^^^^^^^^^^^^
  |
  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)

```
After I enable `macros` and `rt-multi-thread` features of tokio, the demo builds and runs without error.