### PR TITLE
fix: CI error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           rustup set profile minimal
           rustup update --no-self-update stable
-          rustup component add --toolchain stable
           rustup default stable
 
       - name: Cargo Login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,20 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
+        run: |
+          rustup set profile minimal
+          rustup update --no-self-update stable
+          rustup component add --toolchain stable
+          rustup default stable
 
       - name: Cargo Login
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: -- ${{ secrets.CARGO_TOKEN }}
+        run: cargo login ${{ secrets.CARGO_TOKEN }}
 
       - name: Cargo Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
+        run: cargo publish
 
       - name: GitHub Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      
+  workflow_dispatch: # TODO: remove after this workflow works
 
 jobs:
   release:


### PR DESCRIPTION
Fix #85

The stuck may be caused by outdated and unmaintained action since https://github.com/actions-rs is already archived.  
The new config is equivelent to original one. `rustup` is a built-in command now so third-party actions are not needed.  
This could fix the issue ( at least gives a clear error message rather than stuck forever, like https://github.com/MuZhou233/casbin-diesel-adapter/actions/runs/7630193317/job/20785317576 ).