### PR TITLE
feat: Adds the ability to pass in a pool

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -31,6 +31,10 @@ impl DieselAdapter {
             .build(manager)
             .map_err(|err| CasbinError::from(AdapterError(Box::new(Error::PoolError(err)))))?;
 
+        Self::with_pool(pool)
+    }
+
+    pub fn with_pool(pool: Pool<ConnectionManager<adapter::Connection>>) -> Result<Self> {
         let conn = pool
             .get()
             .map_err(|err| CasbinError::from(AdapterError(Box::new(Error::PoolError(err)))));


### PR DESCRIPTION
This change adds a new constructor to the adaptor that allows passing in a DB pool rather than always creating anew.

The existing constructor is altered to use the new constructor in its implementation (which also ensures this code path is tested).